### PR TITLE
Make docs reuse compliant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Please make sure any file you newly create contains a proper license header like
 
 For content in Markdown / React
 ```
-# Copyright (c) <year> Contributors to the Eclipse Foundation
+# SPDX-FileCopyrightText: Copyright (C) <year> Contributors to the Eclipse Foundation
 #
 # These materials are made available under the
 # terms of the Creative Commons Attribution 4.0 International Public License which is available at

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Eclipse Apoapsis Intro
 
 The guidance shall primarily serve as a navigator with a structured landing zone referring to other sources. If no other source are available (yet), or as initial step, the guidance might host some content descriptions in the meanwhile. The structure shall follow a basic principle starting on a generic level and then going into details.

--- a/website/docs/part_A_context_knowledge/basics/elements/index.md
+++ b/website/docs/part_A_context_knowledge/basics/elements/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Elements and Digital Elements
 
 - Generic Element

--- a/website/docs/part_A_context_knowledge/basics/index.md
+++ b/website/docs/part_A_context_knowledge/basics/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Basics
 
 please contribute

--- a/website/docs/part_A_context_knowledge/basics/lifecycles/index.md
+++ b/website/docs/part_A_context_knowledge/basics/lifecycles/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Lifecycles
 
 - Generic Lifecycle of an Element

--- a/website/docs/part_A_context_knowledge/index.md
+++ b/website/docs/part_A_context_knowledge/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # PART A) Context knowledge
 
 *in order to provide a streamlined structure in part B), the part B) will not contain detailed descriptions of contents it refers to. Part B) will assume that this knowledge is known.*

--- a/website/docs/part_A_context_knowledge/management_of_business/index.md
+++ b/website/docs/part_A_context_knowledge/management_of_business/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 4
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Management of Business
 *to describe the supply chain in more detail*
 

--- a/website/docs/part_A_context_knowledge/management_of_organizations/index.md
+++ b/website/docs/part_A_context_knowledge/management_of_organizations/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 3
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Management of Organizations
 *to describe the links of a supply chain in more detail*
 

--- a/website/docs/part_A_context_knowledge/management_of_organizations/management_systems/index.md
+++ b/website/docs/part_A_context_knowledge/management_of_organizations/management_systems/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Management Systems
 
 - Quality Management System

--- a/website/docs/part_A_context_knowledge/management_of_organizations/organization_types/index.md
+++ b/website/docs/part_A_context_knowledge/management_of_organizations/organization_types/index.md
@@ -2,5 +2,21 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Types of Organization
 

--- a/website/docs/part_A_context_knowledge/management_portfolio/index.md
+++ b/website/docs/part_A_context_knowledge/management_portfolio/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 5
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Product/Service Portfolio Management
 *concerns several products/services of an organization*
 

--- a/website/docs/part_A_context_knowledge/management_product/index.md
+++ b/website/docs/part_A_context_knowledge/management_product/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 6
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Product/Service Management
 *to describe one product/service of the portfolio in more detail*
 

--- a/website/docs/part_A_context_knowledge/product_development/A1_integration_approval/a1_integration_approval.md
+++ b/website/docs/part_A_context_knowledge/product_development/A1_integration_approval/a1_integration_approval.md
@@ -3,7 +3,8 @@ sidebar_position: 1
 title: A1 Integration Approval
 ---
 
-<!-- Copyright (c) 2024 Contributors to the Eclipse Foundation
+<!-- 
+SPDX-FileCopyrightText: Copyright (C) 2024 Contributors to the Eclipse Foundation
 
 These materials are made available under the
 terms of the Creative Commons Attribution 4.0 International Public License which is available at
@@ -15,7 +16,8 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations
 under the License.
 
-SPDX-License-Identifier: CC-BY-4.0 -->
+SPDX-License-Identifier: CC-BY-4.0 
+-->
 
 # A1 Integration Approval
 

--- a/website/docs/part_A_context_knowledge/product_development/index.md
+++ b/website/docs/part_A_context_knowledge/product_development/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 7
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Product/Service Development
 *to describe the development phase in more detail*
 

--- a/website/docs/part_A_context_knowledge/supply_chains/generic_supply_chain/index.md
+++ b/website/docs/part_A_context_knowledge/supply_chains/generic_supply_chain/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Generic Supply Chain Model
 
 - Generic links in the supply chain

--- a/website/docs/part_A_context_knowledge/supply_chains/index.md
+++ b/website/docs/part_A_context_knowledge/supply_chains/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Supply Chains
 
 Test 2

--- a/website/docs/part_A_context_knowledge/supply_chains/software_supply_chain/index.md
+++ b/website/docs/part_A_context_knowledge/supply_chains/software_supply_chain/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Software Supply Chain
 
 Links in the Software Supply Chain

--- a/website/docs/part_B_software_management/eclipse_apoapsis_overview.jpg.license
+++ b/website/docs/part_B_software_management/eclipse_apoapsis_overview.jpg.license
@@ -1,8 +1,3 @@
----
-sidebar_position: 3
----
-
-<!--
 SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
 
 These materials are made available under the
@@ -16,12 +11,3 @@ License for the specific language governing permissions and limitations
 under the License.
 
 SPDX-License-Identifier: CC-BY-4.0
--->
-
-# Blueprints for Software Management on Product/Service Level
-
-- **Component Lifecycle Process**
-- Deliverable Dashboards
-- Deliverable Fact Sheet Templates  
-
-Please contribute

--- a/website/docs/part_B_software_management/index.md
+++ b/website/docs/part_B_software_management/index.md
@@ -3,6 +3,22 @@ sidebar_label: 'PART B) - Software and Open Source Management'
 sidebar_position: 3
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # PART B) Software and Open Source Management
 
 ![Eclipse Apoapsis Overview](./eclipse_apoapsis_overview.jpg)

--- a/website/docs/part_B_software_management/sw_development_monitoring/blueprints/ContinuousDevelopmentMonitoring.md
+++ b/website/docs/part_B_software_management/sw_development_monitoring/blueprints/ContinuousDevelopmentMonitoring.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Continuous Development Monitoring
 
 Potential tools:

--- a/website/docs/part_B_software_management/sw_development_monitoring/blueprints/index.md
+++ b/website/docs/part_B_software_management/sw_development_monitoring/blueprints/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 3
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Blueprints for Software Development Monitoring
 
 - [Continuous Development Monitoring (Automated SCA in CI/CD Pipeline)](ContinuousDevelopmentMonitoring.md)

--- a/website/docs/part_B_software_management/sw_development_monitoring/generic_architecture/index.md
+++ b/website/docs/part_B_software_management/sw_development_monitoring/generic_architecture/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Generic Architecture for Software Development Monitoring
 
 Please contribute

--- a/website/docs/part_B_software_management/sw_development_monitoring/problem_space/index.md
+++ b/website/docs/part_B_software_management/sw_development_monitoring/problem_space/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Problem Space
 
 As a [Software Development Team](https://github.com/Open-Source-Compliance/Sharing-creates-value/blob/master/User-Stories/Software-Developer-User-Stories/Software-Developer-Epic.md) I want a [continuous development monitoring](../blueprints/ContinuousDevelopmentMonitoring.md) so that I get fast feedback about the status of non-functional requirements in my project.

--- a/website/docs/part_B_software_management/sw_management_portfolio/blueprints/ProductDashboard.md
+++ b/website/docs/part_B_software_management/sw_management_portfolio/blueprints/ProductDashboard.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Blueprints for Product Dashboards
 
 Potential tools:

--- a/website/docs/part_B_software_management/sw_management_portfolio/blueprints/index.md
+++ b/website/docs/part_B_software_management/sw_management_portfolio/blueprints/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 3
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Blueprints for Software Management on Portfolio Level
 
 - [Product Dashboards](ProductDashboard.md)

--- a/website/docs/part_B_software_management/sw_management_portfolio/generic_architecture/index.md
+++ b/website/docs/part_B_software_management/sw_management_portfolio/generic_architecture/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Generic Architecture for Software Management on Portfolio Level
 
 Please contribute

--- a/website/docs/part_B_software_management/sw_management_portfolio/index.md
+++ b/website/docs/part_B_software_management/sw_management_portfolio/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Software Management on Portfolio Level
 
 Documents are **groups of pages** connected through:

--- a/website/docs/part_B_software_management/sw_management_portfolio/problem_space/index.md
+++ b/website/docs/part_B_software_management/sw_management_portfolio/problem_space/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Problem Space
 
 As a [Compliance Manager](https://github.com/Open-Source-Compliance/Sharing-creates-value/blob/master/User-Stories/Compliance-Manager-User-Stories/ComplianceManager.md) I want to have a Product Dashboard so that I can continuously monitor the compliance status.

--- a/website/docs/part_B_software_management/sw_management_product/blueprints/component_lifecycle_process.md
+++ b/website/docs/part_B_software_management/sw_management_product/blueprints/component_lifecycle_process.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Software Component Lifecycle Process
 [//]: # (SPDX-FileCopyrightText: 2024 Eclipse Apoapsis Contributors)  
 [//]: # (SPDX-License-Identifier: CC-BY-4.0)  

--- a/website/docs/part_B_software_management/sw_management_product/blueprints/process_high_level.jpg.license
+++ b/website/docs/part_B_software_management/sw_management_product/blueprints/process_high_level.jpg.license
@@ -1,8 +1,3 @@
----
-sidebar_position: 3
----
-
-<!--
 SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
 
 These materials are made available under the
@@ -16,12 +11,3 @@ License for the specific language governing permissions and limitations
 under the License.
 
 SPDX-License-Identifier: CC-BY-4.0
--->
-
-# Blueprints for Software Management on Product/Service Level
-
-- **Component Lifecycle Process**
-- Deliverable Dashboards
-- Deliverable Fact Sheet Templates  
-
-Please contribute

--- a/website/docs/part_B_software_management/sw_management_product/blueprints/process_sequences.jpg.license
+++ b/website/docs/part_B_software_management/sw_management_product/blueprints/process_sequences.jpg.license
@@ -1,8 +1,3 @@
----
-sidebar_position: 3
----
-
-<!--
 SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
 
 These materials are made available under the
@@ -16,12 +11,3 @@ License for the specific language governing permissions and limitations
 under the License.
 
 SPDX-License-Identifier: CC-BY-4.0
--->
-
-# Blueprints for Software Management on Product/Service Level
-
-- **Component Lifecycle Process**
-- Deliverable Dashboards
-- Deliverable Fact Sheet Templates  
-
-Please contribute

--- a/website/docs/part_B_software_management/sw_management_product/generic_architecture/index.md
+++ b/website/docs/part_B_software_management/sw_management_product/generic_architecture/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Generic Architecture for Software Management on Product Level
 
 Please contribute

--- a/website/docs/part_B_software_management/sw_management_product/index.md
+++ b/website/docs/part_B_software_management/sw_management_product/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 3
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Software Management on Product/Service Level
 
 tbd

--- a/website/docs/part_B_software_management/sw_management_product/problem_space/index.md
+++ b/website/docs/part_B_software_management/sw_management_product/problem_space/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Problem Space
 
 Please contribute

--- a/website/docs/part_B_software_management/sw_supply_chain_view/blueprints/index.md
+++ b/website/docs/part_B_software_management/sw_supply_chain_view/blueprints/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 3
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Software Supply Chain Blueprints
 
 Please contribute

--- a/website/docs/part_B_software_management/sw_supply_chain_view/generic_architecture/index.md
+++ b/website/docs/part_B_software_management/sw_supply_chain_view/generic_architecture/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 2
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Generic Software Supply Chain Architecture
 
 Please contribute

--- a/website/docs/part_B_software_management/sw_supply_chain_view/index.md
+++ b/website/docs/part_B_software_management/sw_supply_chain_view/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Software Supply Chain View
 
 tbd

--- a/website/docs/part_B_software_management/sw_supply_chain_view/problem_space/index.md
+++ b/website/docs/part_B_software_management/sw_supply_chain_view/problem_space/index.md
@@ -2,6 +2,22 @@
 sidebar_position: 1
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2025 Contributors to the Eclipse Foundation
+
+These materials are made available under the
+terms of the Creative Commons Attribution 4.0 International Public License which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode .
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Problem Space
 
 Please contribute


### PR DESCRIPTION
- added [REUSE](https://reuse.software/spec-3.3/) compliance for all files under _website/docs_ except those under _website/docs/tutorial-extras_ (since I wasn't sure whether they don't actually come the Docusaurus framework)
- adapted standard header in CONTRIBUTING.md file accordingly